### PR TITLE
add a few errorhandler and timeout unit tests

### DIFF
--- a/retrofit-android/build.gradle
+++ b/retrofit-android/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    buildToolsVersion "23.0.2"
 
     lintOptions {
         abortOnError false

--- a/retrofit-android/src/main/java/retrofit/android/AuthenticationInterceptor.java
+++ b/retrofit-android/src/main/java/retrofit/android/AuthenticationInterceptor.java
@@ -13,21 +13,15 @@
  */
 package retrofit.android;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-import android.content.Context;
-import android.text.TextUtils;
-import android.accounts.AccountManager;
 import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.accounts.AccountManagerFuture;
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
-import rx.Observable;
-import rx.functions.*;
-import javax.inject.Singleton;
 import android.util.Log;
+
+import javax.inject.Singleton;
 
 @Singleton
 public abstract class AuthenticationInterceptor extends retrofit.http.Retrofit.SimpleRequestInterceptor {

--- a/retrofit2-github/build.gradle
+++ b/retrofit2-github/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    buildToolsVersion "23.0.2"
 
     lintOptions {
         abortOnError false

--- a/retrofit2-github/src/main/java/com/github/retrofit2/MockErrorHandler.java
+++ b/retrofit2-github/src/main/java/com/github/retrofit2/MockErrorHandler.java
@@ -13,22 +13,53 @@
  */
 package com.github.retrofit2;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 import retrofit.ErrorHandler;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 public class MockErrorHandler implements ErrorHandler {
+    public static int errorCode;
+    public static String responseBody;
+
     @Override public Throwable handleError(RetrofitError cause) {
         System.out.println("MockErrorHandler: " + cause);
         Response r = cause.getResponse();
         System.out.println("MockErrorHandler: Response: " + r);
         if (r != null) {
+            errorCode = r.getStatus();
+            try {
+                responseBody = readString(r.getBody().in(), "UTF-8");
+            } catch(IOException e) {
+                return e;
+            }
+
             System.out.println("MockErrorHandler: status: " + r.getStatus());
             if (r.getStatus() == 401) {
                 return new RuntimeException("401", cause);
             }
         }
         return cause;
+    }
+
+
+    public static String readString(InputStream inputStream, String encoding)
+            throws IOException {
+        return new String(readByteArray(inputStream), encoding);
+    }
+
+    private static byte[] readByteArray(InputStream inputStream)
+            throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length = 0;
+        while ((length = inputStream.read(buffer)) != -1) {
+            baos.write(buffer, 0, length);
+        }
+        return baos.toByteArray();
     }
 }
 

--- a/retrofit2-github/src/main/java/com/github/retrofit2/MockService.java
+++ b/retrofit2-github/src/main/java/com/github/retrofit2/MockService.java
@@ -13,21 +13,14 @@
  */
 package com.github.retrofit2;
 
-import retrofit.http.Retrofit.*;
-import retrofit.http.Retrofit;
-
-import rx.Observable;
-import java.io.File;
-
-import retrofit.converter.*;
-import java.util.List;
-import rx.functions.*;
-import retrofit.mime.TypedFile;
-import retrofit.mime.TypedString;
-import com.github.mobile.model.*;
-import retrofit.client.Response;
-import retrofit.Callback;
 import android.app.Activity;
+
+import retrofit.converter.GsonConverter;
+import retrofit.http.Retrofit;
+import retrofit.http.Retrofit.ErrorHandler;
+import retrofit.http.Retrofit.GET;
+import retrofit.http.Retrofit.LogLevel;
+import retrofit.http.Retrofit.Path;
 
 @Retrofit("https://api.github.com")
 @retrofit.http.Retrofit.Headers({ // optional


### PR DESCRIPTION
also bumped Android built tools to latest and got rid of some unused imports

Note that the errorhandler unit tests don't pass currently because the response body isn't returned if the errorhandler is invoked.  I did confirm the errorhandler is run both ways (annotation and builder).
