### PR TITLE
allow baseUrl to be set from builder pattern

### DIFF
--- a/retrofit-processor/src/main/resources/retrofit/processor/retrofit.vm
+++ b/retrofit-processor/src/main/resources/retrofit/processor/retrofit.vm
@@ -228,9 +228,13 @@ public final class $subclass$formalTypes extends $origClass$actualTypes {
 
 #end
 
+#if ($p.baseUrl != "")
+        baseUrl = "${p.baseUrl}";
+#else
         if (baseUrl == null) {
             baseUrl = "${baseUrl}";
         }
+#end
 
         final Converter finalConverter = myConverter;
 
@@ -418,20 +422,6 @@ public final class $subclass$formalTypes extends $origClass$actualTypes {
 
     #if ($p.requestInterceptor != "")
 
-        requestObs = requestObs.map(new Func1<Request, Request>() {
-            @Override public Request call(Request request) {
-                System.out.println("retrofit: requestInterceptor");
-                SimpleRequestFacade requestFacade = new SimpleRequestFacade(request);
-                if (requestInterceptor instanceof retrofit.http.Retrofit.SimpleRequestInterceptor) {
-                    // FIXME context is tricky
-                    ((retrofit.http.Retrofit.SimpleRequestInterceptor) requestInterceptor).intercept(context, requestFacade);
-                } else {
-                    requestInterceptor.intercept(requestFacade);
-                }
-                return requestFacade.request();
-            }
-        });
-
         #if (!$p.singletonRequestInterceptor)
 
         retrofit.RequestInterceptor myRequestInterceptor = getRequestInterceptor(${p.requestInterceptor}.class);
@@ -526,6 +516,12 @@ public final class $subclass$formalTypes extends $origClass$actualTypes {
                     Request.Builder reqBuilder = requestException.request().newBuilder();
 
         #foreach ($header in $retryHeaders.entrySet())
+
+                    reqBuilder.addHeader("$header.key", $header.value);
+
+        #end
+
+        #foreach ($header in $p.headers.entrySet())
 
                     reqBuilder.addHeader("$header.key", $header.value);
 


### PR DESCRIPTION
remove duplicate request interceptor code if you use builder pattern in addition to @requestinterceptor tag
allow headers to be set from builder pattern

These address problems found from Issues #10 and #11
